### PR TITLE
Breaking: Remove line ending normalization (fixes #7)

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -63,9 +63,6 @@ export function tokenize(text, options) {
         ...options
     });
 
-    // normalize line endings
-    text = text.replace(/\r?\n/g, "\n");
-    
     let offset = -1;
     let line = 1;
     let column = 0;

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -469,10 +469,94 @@ describe("tokenize()", () => {
         ]);
     });
 
-    it("should tokenize object the same regardless of line endings", () => {
+    it("should tokenize objects differently when they have different line endings", () => {
         const result1 = tokenize("{\n\n\"b\": 2}");
         const result2 = tokenize("{\r\n\r\n\"b\": 2}");
-        assertArrayMatches(result1, result2);
+        assertArrayMatches(result1, [
+            {
+                type: 'Punctuator',
+                value: '{',
+                loc: {
+                    start: { line: 1, column: 1, offset: 0 },
+                    end: { line: 1, column: 2, offset: 1 }
+                }
+            },
+            {
+                type: 'String',
+                value: '"b"',
+                loc: {
+                    start: { line: 3, column: 1, offset: 3 },
+                    end: { line: 3, column: 4, offset: 6 }
+                }
+            },
+            {
+                type: 'Punctuator',
+                value: ':',
+                loc: {
+                    start: { line: 3, column: 4, offset: 6 },
+                    end: { line: 3, column: 5, offset: 7 }
+                }
+            },
+            {
+                type: 'Number',
+                value: '2',
+                loc: {
+                    start: { line: 3, column: 6, offset: 8 },
+                    end: { line: 3, column: 7, offset: 9 }
+                }
+            },
+            {
+                type: 'Punctuator',
+                value: '}',
+                loc: {
+                    start: { line: 3, column: 7, offset: 9 },
+                    end: { line: 3, column: 8, offset: 10 }
+                }
+            }
+        ]);
+
+        assertArrayMatches(result2, [
+            {
+                type: 'Punctuator',
+                value: '{',
+                loc: {
+                    start: { line: 1, column: 1, offset: 0 },
+                    end: { line: 1, column: 2, offset: 1 }
+                }
+            },
+            {
+                type: 'String',
+                value: '"b"',
+                loc: {
+                    start: { line: 3, column: 1, offset: 5 },
+                    end: { line: 3, column: 4, offset: 8 }
+                }
+            },
+            {
+                type: 'Punctuator',
+                value: ':',
+                loc: {
+                    start: { line: 3, column: 4, offset: 8 },
+                    end: { line: 3, column: 5, offset: 9 }
+                }
+            },
+            {
+                type: 'Number',
+                value: '2',
+                loc: {
+                    start: { line: 3, column: 6, offset: 10 },
+                    end: { line: 3, column: 7, offset: 11 }
+                }
+            },
+            {
+                type: 'Punctuator',
+                value: '}',
+                loc: {
+                    start: { line: 3, column: 7, offset: 11 },
+                    end: { line: 3, column: 8, offset: 12 }
+                }
+            }
+        ]);
     });
 
 });

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -474,40 +474,40 @@ describe("tokenize()", () => {
         const result2 = tokenize("{\r\n\r\n\"b\": 2}");
         assertArrayMatches(result1, [
             {
-                type: 'Punctuator',
-                value: '{',
+                type: "Punctuator",
+                value: "{",
                 loc: {
                     start: { line: 1, column: 1, offset: 0 },
                     end: { line: 1, column: 2, offset: 1 }
                 }
             },
             {
-                type: 'String',
-                value: '"b"',
+                type: "String",
+                value: "\"b\"",
                 loc: {
                     start: { line: 3, column: 1, offset: 3 },
                     end: { line: 3, column: 4, offset: 6 }
                 }
             },
             {
-                type: 'Punctuator',
-                value: ':',
+                type: "Punctuator",
+                value: ":",
                 loc: {
                     start: { line: 3, column: 4, offset: 6 },
                     end: { line: 3, column: 5, offset: 7 }
                 }
             },
             {
-                type: 'Number',
-                value: '2',
+                type: "Number",
+                value: "2",
                 loc: {
                     start: { line: 3, column: 6, offset: 8 },
                     end: { line: 3, column: 7, offset: 9 }
                 }
             },
             {
-                type: 'Punctuator',
-                value: '}',
+                type: "Punctuator",
+                value: "}",
                 loc: {
                     start: { line: 3, column: 7, offset: 9 },
                     end: { line: 3, column: 8, offset: 10 }
@@ -517,40 +517,40 @@ describe("tokenize()", () => {
 
         assertArrayMatches(result2, [
             {
-                type: 'Punctuator',
-                value: '{',
+                type: "Punctuator",
+                value: "{",
                 loc: {
                     start: { line: 1, column: 1, offset: 0 },
                     end: { line: 1, column: 2, offset: 1 }
                 }
             },
             {
-                type: 'String',
-                value: '"b"',
+                type: "String",
+                value: "\"b\"",
                 loc: {
                     start: { line: 3, column: 1, offset: 5 },
                     end: { line: 3, column: 4, offset: 8 }
                 }
             },
             {
-                type: 'Punctuator',
-                value: ':',
+                type: "Punctuator",
+                value: ":",
                 loc: {
                     start: { line: 3, column: 4, offset: 8 },
                     end: { line: 3, column: 5, offset: 9 }
                 }
             },
             {
-                type: 'Number',
-                value: '2',
+                type: "Number",
+                value: "2",
                 loc: {
                     start: { line: 3, column: 6, offset: 10 },
                     end: { line: 3, column: 7, offset: 11 }
                 }
             },
             {
-                type: 'Punctuator',
-                value: '}',
+                type: "Punctuator",
+                value: "}",
                 loc: {
                     start: { line: 3, column: 7, offset: 11 },
                     end: { line: 3, column: 8, offset: 12 }


### PR DESCRIPTION
I think I added line ending normalization to make parsing easier, but it's already pretty easy, so I'm removing the normalization to make the token locations less confusing.