### PR TITLE
Produce error on dangling array comma.

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -261,18 +261,21 @@ export function parse(text, options) {
         const elements = [];
         let token = next();
         
-        while (token && token.value !== "]") {
+        if (token && token.value !== "]") {
 
-            // add the value into the array
-            elements.push(parseValue(token));
+            do {
 
-            token = next();
-            
-            if (token.value === ",") {
-                token = next();
-            } else {
-                break;
-            }
+              // add the value into the array
+              elements.push(parseValue(token));
+
+              token = next();
+              
+              if (token.value === ",") {
+                  token = next();
+              } else {
+                  break;
+              }
+            } while (token);
         }
 
         assertTokenValue(token, "]");

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -55,6 +55,16 @@ describe("parse()", () => {
                 parse(text);
             }).to.throw("Unexpected token Punctuator(}) found.");
         });
+
+        it("should throw an error when there is a dangling comma in an array", () => {
+            const text = `[
+   1,
+]`;
+
+            expect(() => {
+                parse(text);
+            }).to.throw("Unexpected token Punctuator(]) found.");
+        });
     });
 
     describe("tokens", () => {


### PR DESCRIPTION
Fixes #19 - produces a syntax error when an array contains a dangling comma.