### PR TITLE
Consolidating imports/exports and update library type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
+crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib"]
+path = "src/lib.rs"
 
 [dependencies]
 wasm-bindgen = "0.2.74"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,4 @@
-use std::fmt;
-use thiserror::Error;
-use crate::location::Location;
+use crate::prelude::*;
 
 #[derive(Error)]
 pub enum MomoaError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,17 @@ mod tokens;
 mod errors;
 mod location;
 
-pub use tokens::{tokenize, TokenKind};
-pub use location::{Location, LocationRange};
-pub use errors::MomoaError;
+// consolidate imports from local files and external crates
+mod prelude {
+    pub use std::collections::HashMap;
+    pub use std::fmt;
+    pub use std::iter::Peekable;
+    pub use thiserror::Error;
+
+    pub use crate::errors::MomoaError;
+    pub use crate::location::{Location, LocationRange};
+    pub use crate::tokens::{tokenize, TokenKind};
+}
+
+// expose specific apis from the library
+pub use prelude::{tokenize, Location, TokenKind};

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-use std::iter::Peekable;
-use crate::errors::MomoaError;
-use crate::location::*;
+use crate::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenKind {


### PR DESCRIPTION
### Consolidating imports/exports and change lib type
AFAIK `cdylib` type crates need apis to be exported using the `extern` keyword. The structs exported from the library would require `#[Repr(C)]` macro to create a C compatible binary.

However if it's to be used in rust projects only we can let the compiler choose the output by omitting `crate-type` from the `Cargo.toml`. That fixes an error I was seeing with the `momoa` import in the integration tests.

I've been using the `prelude` module in my projects to streamline the dependencies and exports.