### PR TITLE
Add CommonJS types to fix node16 module resolution

### DIFF
--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 2018,
+        "ecmaVersion": 2020,
         "sourceType": "module"
     },
     "rules": {

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,8 @@
   "files": [
     "dist/momoa.js",
     "dist/momoa.cjs",
-    "dist/momoa.d.ts"
+    "dist/momoa.d.ts",
+    "dist/momoa.d.cts"
   ],
   "repository": {
     "type": "git",

--- a/js/rollup.types.js
+++ b/js/rollup.types.js
@@ -12,5 +12,17 @@ export default [
         plugins: [
             dts()
         ]
+    },
+    {
+        input: "temp/momoa.d.ts",
+        output: [
+            {
+                file: "dist/momoa.d.cts",
+                format: "commonjs"
+            }
+        ],
+        plugins: [
+            dts()
+        ]
     }
 ];

--- a/js/tests/fixtures/ts-project-module-node16-cjs/index.ts
+++ b/js/tests/fixtures/ts-project-module-node16-cjs/index.ts
@@ -1,0 +1,4 @@
+import { parse } from "@humanwhocodes/momoa";
+
+const ast = parse(`{ "a": 1 }`)
+console.log(ast);

--- a/js/tests/fixtures/ts-project-module-node16-cjs/package-lock.json
+++ b/js/tests/fixtures/ts-project-module-node16-cjs/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "momoa-node16",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "momoa-node16",
+      "version": "1.0.0",
+      "dependencies": {
+        "@humanwhocodes/momoa": "file:../../../"
+      }
+    },
+    "../../..": {
+      "name": "@humanwhocodes/momoa",
+      "version": "3.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "chai": "^4.3.7",
+        "eslint": "8.36.0",
+        "esm": "3.2.25",
+        "json-to-ast": "2.1.0",
+        "mocha": "^10.2.0",
+        "npm-run-all": "^4.1.5",
+        "rollup": "^3.3.0",
+        "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-dts": "^5.2.0",
+        "sinon": "^15.0.1",
+        "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "resolved": "../../..",
+      "link": true
+    }
+  }
+}

--- a/js/tests/fixtures/ts-project-module-node16-cjs/package.json
+++ b/js/tests/fixtures/ts-project-module-node16-cjs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "momoa-node16",
+  "version": "1.0.0",
+  "description": "Fixture of a CJS TS consumer using `moduleResolution: node16`",
+  "exports": "./index.js",
+  "author": "",
+  "scripts": {
+    "prepare": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@humanwhocodes/momoa": "file:../../../"
+  }
+}

--- a/js/tests/fixtures/ts-project-module-node16-cjs/tsconfig.json
+++ b/js/tests/fixtures/ts-project-module-node16-cjs/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "module": "node16",
+        "moduleResolution": "node16",
+        "moduleDetection": "force",
+        "target": "ES2022", // Node.js 18
+        "lib": [
+            "ES2022"
+        ],
+        "strict": true
+    }
+}

--- a/js/tests/fixtures/ts-project-module-node16-esm/index.ts
+++ b/js/tests/fixtures/ts-project-module-node16-esm/index.ts
@@ -1,0 +1,4 @@
+import { parse } from "@humanwhocodes/momoa";
+
+const ast = parse(`{ "a": 1 }`)
+console.log(ast);

--- a/js/tests/fixtures/ts-project-module-node16-esm/package-lock.json
+++ b/js/tests/fixtures/ts-project-module-node16-esm/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "momoa-node16",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "momoa-node16",
+      "version": "1.0.0",
+      "dependencies": {
+        "@humanwhocodes/momoa": "file:../../../"
+      }
+    },
+    "../../..": {
+      "name": "@humanwhocodes/momoa",
+      "version": "3.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "chai": "^4.3.7",
+        "eslint": "8.36.0",
+        "esm": "3.2.25",
+        "json-to-ast": "2.1.0",
+        "mocha": "^10.2.0",
+        "npm-run-all": "^4.1.5",
+        "rollup": "^3.3.0",
+        "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-dts": "^5.2.0",
+        "sinon": "^15.0.1",
+        "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "resolved": "../../..",
+      "link": true
+    }
+  }
+}

--- a/js/tests/fixtures/ts-project-module-node16-esm/package.json
+++ b/js/tests/fixtures/ts-project-module-node16-esm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "momoa-node16",
+  "version": "1.0.0",
+  "description": "Fixture of an ESM TS consumer using `moduleResolution: node16`",
+  "exports": "./index.js",
+  "author": "",
+  "type": "module",
+  "scripts": {
+    "prepare": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@humanwhocodes/momoa": "file:../../../"
+  }
+}

--- a/js/tests/fixtures/ts-project-module-node16-esm/tsconfig.json
+++ b/js/tests/fixtures/ts-project-module-node16-esm/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "module": "node16",
+        "moduleResolution": "node16",
+        "moduleDetection": "force",
+        "target": "ES2022", // Node.js 18
+        "lib": [
+            "ES2022"
+        ],
+        "strict": true
+    }
+}

--- a/js/tests/types.test.js
+++ b/js/tests/types.test.js
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Tests that node16 moduleResolution imports succeed.
+ */
+/* eslint-disable no-console */
+
+import { execSync } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BASE_FIXTURE_DIR = path.join(__dirname, "fixtures");
+const FIXTURE_DIRS = [
+    path.join(BASE_FIXTURE_DIR, "ts-project-module-node16-cjs"),
+    path.join(BASE_FIXTURE_DIR, "ts-project-module-node16-esm"),
+];
+
+try {
+    for (const dir of FIXTURE_DIRS) {
+        execSync("npm i", {cwd: dir});
+        console.log(`${path.relative(__dirname, dir)}: success`);
+    }
+    console.log("node16 type loading: success");
+} catch (err) {
+    const error =
+    /** @type {Error & import('child_process').SpawnSyncReturns<string>} */ (
+            err
+        );
+    console.error(error.stdout);
+    console.error(error.stderr);
+    process.exit(1);
+}


### PR DESCRIPTION
This adds separate CommonJS types to fix projects using node16 moduleResolution
https://www.typescriptlang.org/tsconfig#moduleResolution

The types in a package can be checked here:
https://arethetypeswrong.github.io/?p=%40humanwhocodes%2Fmomoa%403.0.0