### PR TITLE
fix(perf): Compare char codes for 100% speed up

### DIFF
--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 2020,
+        "ecmaVersion": "latest",
         "sourceType": "module"
     },
     "rules": {

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -22,7 +22,7 @@
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-dts": "^6.1.1",
         "sinon": "^15.0.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.5.4"
       },
       "engines": {
         "node": ">=18"
@@ -3350,16 +3350,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6007,9 +6007,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
     "unbox-primitive": {

--- a/js/package.json
+++ b/js/package.json
@@ -59,6 +59,6 @@
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-dts": "^6.1.1",
     "sinon": "^15.0.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.5.4"
   }
 }

--- a/js/src/char-code-reader.js
+++ b/js/src/char-code-reader.js
@@ -1,0 +1,163 @@
+/**
+ * @fileoverview A charactor code reader.
+ * @author Nicholas C. Zakas
+ */
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/** @typedef {import("./typedefs.ts").Location} Location */
+
+//-----------------------------------------------------------------------------
+// Data
+//-----------------------------------------------------------------------------
+
+const CHAR_CR = 13; // \r
+const CHAR_LF = 10; // \n
+
+//-----------------------------------------------------------------------------
+// CharCodeReader
+//-----------------------------------------------------------------------------
+
+/**
+ * A reader that reads character codes from a string.
+ */
+export class CharCodeReader {
+
+    /**
+     * The text to read from.
+     * @type {string}
+     */
+    #text = "";
+
+    /**
+     * The current line number.
+     * @type {number}
+     */
+    #line = 1;
+
+    /**
+     * The current column number.
+     * @type {number}
+     */
+    #column = 0;
+
+    /**
+     * The current offset in the text.
+     * @type {number}
+     */
+    #offset = -1;
+
+    /**
+     * Whether the last character read was a new line.
+     * @type {boolean}
+     */
+    #newLine = false;
+
+    /**
+     * The last character code read.
+     * @type {number}
+     */
+    #last = -1;
+
+    /**
+     * Whether the reader has ended.
+     * @type {boolean}
+     */
+    #ended = false;
+
+    /**
+     * Creates a new instance.
+     * @param {string} text The text to read from
+     */
+    constructor(text) {
+        this.#text = text;
+    }
+
+    /**
+     * Ends the reader.
+     * @returns {void}
+     */
+    #end() {
+        if (this.#ended) {
+            return;
+        }
+
+        this.#column++;
+        this.#offset++;
+        this.#last = -1;
+        this.#ended = true;
+    }
+
+    /**
+     * Returns the current position of the reader.
+     * @returns {Location} An object with line, column, and offset properties.
+     */
+    locate() {
+        return {
+            line: this.#line,
+            column: this.#column,
+            offset: this.#offset
+        };
+    }
+
+    /**
+     * Reads the next character code in the text.
+     * @returns {number} The next character code, or -1 if there are no more characters.
+     */
+    next() {
+        if (this.#offset >= this.#text.length - 1) {
+            this.#end();
+            return -1;
+        }
+
+        this.#offset++;
+        const charCode = this.#text.charCodeAt(this.#offset);
+
+        if (this.#newLine) {
+            this.#line++;
+            this.#column = 1;
+            this.#newLine = false;
+        } else {
+            this.#column++;
+        }
+
+        if (charCode === CHAR_CR) {
+            this.#newLine = true;
+
+            // if we already see a \r, just ignore upcoming \n
+            if (this.peek() === CHAR_LF) {
+                this.#offset++;
+            }
+        } else if (charCode === CHAR_LF) {
+            this.#newLine = true;
+        }
+
+        this.#last = charCode;
+
+        return charCode;
+    }
+
+    /**
+     * Peeks at the next character code in the text.
+     * @returns {number} The next character code, or -1 if there are no more characters.
+     */
+    peek() {
+        if (this.#offset === this.#text.length - 1) {
+            return -1;
+        }
+
+        return this.#text.charCodeAt(this.#offset + 1);
+    }
+
+    /**
+     * Returns the last character code read.
+     * @returns {number} The last character code read.
+     */
+    current() {
+        return this.#last;
+    }
+
+
+}

--- a/js/src/char-codes.js
+++ b/js/src/char-codes.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Character codes.
+ * @author Nicholas C. Zakas
+ */
+
+export const CHAR_0 = 48;          // 0
+export const CHAR_1 = 49;          // 1
+export const CHAR_9 = 57;          // 9
+export const CHAR_BACKSLASH = 92;  // \
+export const CHAR_DOLLAR = 36;     // $
+export const CHAR_DOT = 46;        // .
+export const CHAR_DOUBLE_QUOTE = 34; // "
+export const CHAR_LOWER_A = 97;    // a
+export const CHAR_LOWER_E = 101;         // e
+export const CHAR_LOWER_F = 102;   // f
+export const CHAR_LOWER_N = 110;   // n
+export const CHAR_LOWER_T = 116;   // t
+export const CHAR_LOWER_U = 117;   // u
+export const CHAR_LOWER_X = 120;   // x
+export const CHAR_LOWER_Z = 122;   // z
+export const CHAR_MINUS = 45;      // -
+export const CHAR_NEWLINE = 10;    // newline
+export const CHAR_PLUS = 43;       // +
+export const CHAR_RETURN = 13;     // return
+export const CHAR_SINGLE_QUOTE = 39; // '
+export const CHAR_SLASH = 47;      // /
+export const CHAR_SPACE = 32;      // space
+export const CHAR_TAB = 9;         // tab
+export const CHAR_UNDERSCORE = 95; // _
+export const CHAR_UPPER_A = 65;    // A
+export const CHAR_UPPER_E = 69;          // E
+export const CHAR_UPPER_F = 70;    // F
+export const CHAR_UPPER_N = 78;    // N
+export const CHAR_UPPER_X = 88;    // X
+export const CHAR_UPPER_Z = 90;    // Z
+export const CHAR_LOWER_B = 98;    // b
+export const CHAR_LOWER_R = 114;   // r
+export const CHAR_LOWER_V = 118;   // v
+export const CHAR_LINE_SEPARATOR = 0x2028;
+export const CHAR_PARAGRAPH_SEPARATOR = 0x2029;
+export const CHAR_LOWER_L = 108;   // l
+export const CHAR_LOWER_S = 115;   // s
+export const CHAR_LOWER_C = 99;    // c
+export const CHAR_UPPER_I = 73;    // I
+export const CHAR_STAR = 42;       // *
+export const CHAR_VTAB = 11;            // U+000B Vertical tab
+export const CHAR_FORM_FEED = 12;       // U+000C Form feed
+export const CHAR_NBSP = 160;           // U+00A0 Non-breaking space
+export const CHAR_BOM = 65279;          // U+FEFF
+export const CHAR_NON_BREAKING_SPACE = 160;
+export const CHAR_EN_QUAD = 8192;
+export const CHAR_EM_QUAD = 8193;
+export const CHAR_EN_SPACE = 8194;
+export const CHAR_EM_SPACE = 8195;
+export const CHAR_THREE_PER_EM_SPACE = 8196;
+export const CHAR_FOUR_PER_EM_SPACE = 8197;
+export const CHAR_SIX_PER_EM_SPACE = 8198;
+export const CHAR_FIGURE_SPACE = 8199;
+export const CHAR_PUNCTUATION_SPACE = 8200;
+export const CHAR_THIN_SPACE = 8201;
+export const CHAR_HAIR_SPACE = 8202;
+export const CHAR_NARROW_NO_BREAK_SPACE = 8239;
+export const CHAR_MEDIUM_MATHEMATICAL_SPACE = 8287;
+export const CHAR_IDEOGRAPHIC_SPACE = 12288;

--- a/js/src/errors.js
+++ b/js/src/errors.js
@@ -7,8 +7,8 @@
 // Typedefs
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").Location} Location */
-/** @typedef {import("./typedefs").Token} Token */
+/** @typedef {import("./typedefs.ts").Location} Location */
+/** @typedef {import("./typedefs.ts").Token} Token */
 
 //-----------------------------------------------------------------------------
 // Errors
@@ -55,11 +55,11 @@ export class UnexpectedChar extends ErrorWithLocation {
 
     /**
      * Creates a new instance.
-     * @param {string} unexpected The character that was found.
+     * @param {number} unexpected The character that was found.
      * @param {Location} loc The location information for the found character.
      */
     constructor(unexpected, loc) {
-        super(`Unexpected character '${ unexpected }' found.`, loc);
+        super(`Unexpected character '${ String.fromCharCode(unexpected) }' found.`, loc);
     }
 }
 

--- a/js/src/evaluate.js
+++ b/js/src/evaluate.js
@@ -7,19 +7,19 @@
 // Typedefs
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").Node} Node */
-/** @typedef {import("./typedefs").NodeParts} NodeParts */
-/** @typedef {import("./typedefs").DocumentNode} DocumentNode */
-/** @typedef {import("./typedefs").StringNode} StringNode */
-/** @typedef {import("./typedefs").NumberNode} NumberNode */
-/** @typedef {import("./typedefs").BooleanNode} BooleanNode */
-/** @typedef {import("./typedefs").MemberNode} MemberNode */
-/** @typedef {import("./typedefs").ObjectNode} ObjectNode */
-/** @typedef {import("./typedefs").ElementNode} ElementNode */
-/** @typedef {import("./typedefs").ArrayNode} ArrayNode */
-/** @typedef {import("./typedefs").NullNode} NullNode */
-/** @typedef {import("./typedefs").AnyNode} AnyNode */
-/** @typedef {import("./typedefs").JSONValue} JSONValue */
+/** @typedef {import("./typedefs.ts").Node} Node */
+/** @typedef {import("./typedefs.ts").NodeParts} NodeParts */
+/** @typedef {import("./typedefs.ts").DocumentNode} DocumentNode */
+/** @typedef {import("./typedefs.ts").StringNode} StringNode */
+/** @typedef {import("./typedefs.ts").NumberNode} NumberNode */
+/** @typedef {import("./typedefs.ts").BooleanNode} BooleanNode */
+/** @typedef {import("./typedefs.ts").MemberNode} MemberNode */
+/** @typedef {import("./typedefs.ts").ObjectNode} ObjectNode */
+/** @typedef {import("./typedefs.ts").ElementNode} ElementNode */
+/** @typedef {import("./typedefs.ts").ArrayNode} ArrayNode */
+/** @typedef {import("./typedefs.ts").NullNode} NullNode */
+/** @typedef {import("./typedefs.ts").AnyNode} AnyNode */
+/** @typedef {import("./typedefs.ts").JSONValue} JSONValue */
 
 //-----------------------------------------------------------------------------
 // Exports

--- a/js/src/parse.js
+++ b/js/src/parse.js
@@ -17,25 +17,25 @@ import { UnexpectedToken, ErrorWithLocation, UnexpectedEOF } from "./errors.js";
 // Typedefs
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").Location} Location */
-/** @typedef {import("./typedefs").Token} Token */
-/** @typedef {import("./typedefs").TokenType} TokenType */
-/** @typedef {import("./typedefs").Node} Node */
-/** @typedef {import("./typedefs").Mode} Mode */
-/** @typedef {import("./typedefs").ParseOptions} ParseOptions */
-/** @typedef {import("./typedefs").DocumentNode} DocumentNode */
-/** @typedef {import("./typedefs").StringNode} StringNode */
-/** @typedef {import("./typedefs").NumberNode} NumberNode */
-/** @typedef {import("./typedefs").BooleanNode} BooleanNode */
-/** @typedef {import("./typedefs").MemberNode} MemberNode */
-/** @typedef {import("./typedefs").ObjectNode} ObjectNode */
-/** @typedef {import("./typedefs").ElementNode} ElementNode */
-/** @typedef {import("./typedefs").ArrayNode} ArrayNode */
-/** @typedef {import("./typedefs").NullNode} NullNode */
-/** @typedef {import("./typedefs").IdentifierNode} IdentifierNode */
-/** @typedef {import("./typedefs").NaNNode} NaNNode */
-/** @typedef {import("./typedefs").InfinityNode} InfinityNode */
-/** @typedef {import("./typedefs").Sign} Sign */
+/** @typedef {import("./typedefs.ts").Location} Location */
+/** @typedef {import("./typedefs.ts").Token} Token */
+/** @typedef {import("./typedefs.ts").TokenType} TokenType */
+/** @typedef {import("./typedefs.ts").Node} Node */
+/** @typedef {import("./typedefs.ts").Mode} Mode */
+/** @typedef {import("./typedefs.ts").ParseOptions} ParseOptions */
+/** @typedef {import("./typedefs.ts").DocumentNode} DocumentNode */
+/** @typedef {import("./typedefs.ts").StringNode} StringNode */
+/** @typedef {import("./typedefs.ts").NumberNode} NumberNode */
+/** @typedef {import("./typedefs.ts").BooleanNode} BooleanNode */
+/** @typedef {import("./typedefs.ts").MemberNode} MemberNode */
+/** @typedef {import("./typedefs.ts").ObjectNode} ObjectNode */
+/** @typedef {import("./typedefs.ts").ElementNode} ElementNode */
+/** @typedef {import("./typedefs.ts").ArrayNode} ArrayNode */
+/** @typedef {import("./typedefs.ts").NullNode} NullNode */
+/** @typedef {import("./typedefs.ts").IdentifierNode} IdentifierNode */
+/** @typedef {import("./typedefs.ts").NaNNode} NaNNode */
+/** @typedef {import("./typedefs.ts").InfinityNode} InfinityNode */
+/** @typedef {import("./typedefs.ts").Sign} Sign */
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -70,13 +70,14 @@ function getStringValue(value, token, json5 = false) {
 
         // get the character immediately after the \
         const escapeChar = value.charAt(escapeIndex + 1);
+        const escapeCharCode = escapeChar.charCodeAt(0);
         
         // check for the non-Unicode escape sequences first
-        if (json5 && json5EscapeToChar.has(escapeChar)) {
-            result += json5EscapeToChar.get(escapeChar);
+        if (json5 && json5EscapeToChar.has(escapeCharCode)) {
+            result += json5EscapeToChar.get(escapeCharCode);
             lastIndex = escapeIndex + 2;
-        } else if (escapeToChar.has(escapeChar)) {
-            result += escapeToChar.get(escapeChar);
+        } else if (escapeToChar.has(escapeCharCode)) {
+            result += escapeToChar.get(escapeCharCode);
             lastIndex = escapeIndex + 2;
         } else if (escapeChar === "u") {
             const hexCode = value.slice(escapeIndex + 2, escapeIndex + 6);
@@ -108,7 +109,7 @@ function getStringValue(value, token, json5 = false) {
 
             result += String.fromCharCode(parseInt(hexCode, 16));
             lastIndex = escapeIndex + 4;
-        } else if (json5 && json5LineTerminators.has(escapeChar)) {
+        } else if (json5 && json5LineTerminators.has(escapeCharCode)) {
             lastIndex = escapeIndex + 2;
 
             // we also need to skip \n after a \r

--- a/js/src/print.js
+++ b/js/src/print.js
@@ -13,18 +13,18 @@ import { json5CharToEscape } from "./syntax.js";
 // Typedefs
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").Location} Location */
-/** @typedef {import("./typedefs").AnyNode} AnyNode */
-/** @typedef {import("./typedefs").BooleanNode} BooleanNode */
-/** @typedef {import("./typedefs").NumberNode} NumberNode */
-/** @typedef {import("./typedefs").NullNode} NullNode */
-/** @typedef {import("./typedefs").NaNNode} NaNNode */
-/** @typedef {import("./typedefs").InfinityNode} InfinityNode */
-/** @typedef {import("./typedefs").StringNode} StringNode */
-/** @typedef {import("./typedefs").IdentifierNode} IdentifierNode */
-/** @typedef {import("./typedefs").ObjectNode} ObjectNode */
-/** @typedef {import("./typedefs").ArrayNode} ArrayNode */
-/** @typedef {import("./typedefs").MemberNode} MemberNode */
+/** @typedef {import("./typedefs.ts").Location} Location */
+/** @typedef {import("./typedefs.ts").AnyNode} AnyNode */
+/** @typedef {import("./typedefs.ts").BooleanNode} BooleanNode */
+/** @typedef {import("./typedefs.ts").NumberNode} NumberNode */
+/** @typedef {import("./typedefs.ts").NullNode} NullNode */
+/** @typedef {import("./typedefs.ts").NaNNode} NaNNode */
+/** @typedef {import("./typedefs.ts").InfinityNode} InfinityNode */
+/** @typedef {import("./typedefs.ts").StringNode} StringNode */
+/** @typedef {import("./typedefs.ts").IdentifierNode} IdentifierNode */
+/** @typedef {import("./typedefs.ts").ObjectNode} ObjectNode */
+/** @typedef {import("./typedefs.ts").ArrayNode} ArrayNode */
+/** @typedef {import("./typedefs.ts").MemberNode} MemberNode */
 
 //-----------------------------------------------------------------------------
 // Helpers

--- a/js/src/syntax.js
+++ b/js/src/syntax.js
@@ -4,10 +4,16 @@
  */
 
 //-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import * as charCodes from "./char-codes.js";
+
+//-----------------------------------------------------------------------------
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").TokenType} TokenType */
+/** @typedef {import("./typedefs.ts").TokenType} TokenType */
 
 //-----------------------------------------------------------------------------
 // Predefined Tokens
@@ -26,6 +32,7 @@ const NULL = "null";
 const NAN = "NaN";
 const INFINITY = "Infinity";
 const QUOTE = "\"";
+
 
 //-----------------------------------------------------------------------------
 // Token Collections
@@ -70,26 +77,26 @@ export const json5HexDigits = new Set([
 ]);
 
 export const expectedKeywords = new Map([
-    ["t", TRUE],
-    ["f", FALSE],
-    ["n", NULL]
+    [charCodes.CHAR_LOWER_T, [charCodes.CHAR_LOWER_R, charCodes.CHAR_LOWER_U, charCodes.CHAR_LOWER_E]],
+    [charCodes.CHAR_LOWER_F, [charCodes.CHAR_LOWER_A, charCodes.CHAR_LOWER_L, charCodes.CHAR_LOWER_S, charCodes.CHAR_LOWER_E]],
+    [charCodes.CHAR_LOWER_N, [charCodes.CHAR_LOWER_U, charCodes.CHAR_LOWER_L, charCodes.CHAR_LOWER_L]]
 ]);
 
 export const escapeToChar = new Map([
-    [QUOTE, QUOTE],
-    ["\\", "\\"],
-    ["/", "/"],
-    ["b", "\b"],
-    ["n", "\n"],
-    ["f", "\f"],
-    ["r", "\r"],
-    ["t", "\t"]
+    [charCodes.CHAR_DOUBLE_QUOTE, QUOTE],
+    [charCodes.CHAR_BACKSLASH, "\\"],
+    [charCodes.CHAR_SLASH, "/"],
+    [charCodes.CHAR_LOWER_B, "\b"],
+    [charCodes.CHAR_LOWER_N, "\n"],
+    [charCodes.CHAR_LOWER_F, "\f"],
+    [charCodes.CHAR_LOWER_R, "\r"],
+    [charCodes.CHAR_LOWER_T, "\t"]
 ]);
 
 export const json5EscapeToChar = new Map([
     ...escapeToChar,
-    ["v", "\v"],
-    ["0", "\0"]
+    [charCodes.CHAR_LOWER_V, "\v"],
+    [charCodes.CHAR_0, "\0"]
 ]);
 
 export const charToEscape = new Map([
@@ -133,8 +140,8 @@ export const knownJSON5TokenTypes = new Map([
 
 // JSON5
 export const json5LineTerminators = new Set([
-    "\n",
-    "\r",
-    "\u2028",
-    "\u2029"
+    charCodes.CHAR_NEWLINE,
+    charCodes.CHAR_RETURN,
+    charCodes.CHAR_LINE_SEPARATOR,
+    charCodes.CHAR_PARAGRAPH_SEPARATOR
 ]);

--- a/js/src/tokens.js
+++ b/js/src/tokens.js
@@ -17,97 +17,171 @@ import {
 } from "./syntax.js";
 import { UnexpectedChar, UnexpectedEOF } from "./errors.js";
 import { ID_Start, ID_Continue } from "./unicode.js";
+import { CharCodeReader } from "./char-code-reader.js";
+import * as charCodes from "./char-codes.js";
 
 //-----------------------------------------------------------------------------
 // Typedefs
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").Location} Location */
-/** @typedef {import("./typedefs").Range} Range */
-/** @typedef {import("./typedefs").Token} Token */
-/** @typedef {import("./typedefs").TokenType} TokenType */
-/** @typedef {import("./typedefs").TokenizeOptions} TokenizeOptions */
+/** @typedef {import("./typedefs.ts").Location} Location */
+/** @typedef {import("./typedefs.ts").Range} Range */
+/** @typedef {import("./typedefs.ts").Token} Token */
+/** @typedef {import("./typedefs.ts").TokenType} TokenType */
+/** @typedef {import("./typedefs.ts").TokenizeOptions} TokenizeOptions */
 
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------
 
-const DOUBLE_QUOTE = "\"";
-const SINGLE_QUOTE = "'";
-const SLASH = "/";
-const STAR = "*";
 const INFINITY = "Infinity";
 const NAN = "NaN";
+
+const keywordStarts = new Set([charCodes.CHAR_LOWER_T, charCodes.CHAR_LOWER_F, charCodes.CHAR_LOWER_N]);
+const whitespace = new Set([charCodes.CHAR_SPACE, charCodes.CHAR_TAB, charCodes.CHAR_NEWLINE, charCodes.CHAR_RETURN]);
+const json5Whitespace = new Set([
+    ...whitespace,
+    charCodes.CHAR_VTAB,
+    charCodes.CHAR_FORM_FEED,
+    charCodes.CHAR_NBSP,
+    charCodes.CHAR_LINE_SEPARATOR,
+    charCodes.CHAR_PARAGRAPH_SEPARATOR,
+    charCodes.CHAR_BOM,
+    charCodes.CHAR_NON_BREAKING_SPACE,
+    charCodes.CHAR_EN_QUAD,
+    charCodes.CHAR_EM_QUAD,
+    charCodes.CHAR_EN_SPACE,
+    charCodes.CHAR_EM_SPACE,
+    charCodes.CHAR_THREE_PER_EM_SPACE,
+    charCodes.CHAR_FOUR_PER_EM_SPACE,
+    charCodes.CHAR_SIX_PER_EM_SPACE,
+    charCodes.CHAR_FIGURE_SPACE,
+    charCodes.CHAR_PUNCTUATION_SPACE,
+    charCodes.CHAR_THIN_SPACE,
+    charCodes.CHAR_HAIR_SPACE,
+    charCodes.CHAR_NARROW_NO_BREAK_SPACE,
+    charCodes.CHAR_MEDIUM_MATHEMATICAL_SPACE,
+    charCodes.CHAR_IDEOGRAPHIC_SPACE,
+]);
+
 
 const DEFAULT_OPTIONS = {
     mode: "json",
     ranges: false
 };
 
-function isWhitespace(c) {
-    return /[\s\n]/.test(c);
-}
+// #region Helpers
 
+
+/**
+ * Determines if a given character is a decimal digit.
+ * @param {number} c The character to check.
+ * @returns {boolean} `true` if the character is a digit.
+ */
 function isDigit(c) {
-    return c >= "0" && c <= "9";
+    return c >= charCodes.CHAR_0 && c <= charCodes.CHAR_9;
 }
 
+/**
+ * Determines if a given character is a hexadecimal digit.
+ * @param {number} c The character to check.
+ * @returns {boolean} `true` if the character is a hexadecimal digit.
+ */
 function isHexDigit(c) {
-    return isDigit(c) || /[a-f]/i.test(c);
+    return isDigit(c) ||
+        c >= charCodes.CHAR_UPPER_A && c <= charCodes.CHAR_UPPER_F ||
+        c >= charCodes.CHAR_LOWER_A && c <= charCodes.CHAR_LOWER_F;
 }
 
+/**
+ * Determines if a given character is a positive digit (1-9).
+ * @param {number} c The character to check.
+ * @returns {boolean} `true` if the character is a positive digit.
+ */
 function isPositiveDigit(c) {
-    return c >= "1" && c <= "9";
+    return c >= charCodes.CHAR_1 && c <= charCodes.CHAR_9;
 }
 
+/**
+ * Determines if a given character is the start of a keyword.
+ * @param {number} c The character to check.
+ * @returns {boolean} `true` if the character is the start of a keyword.
+ */
 function isKeywordStart(c) {
-    return /[tfn]/.test(c);
+    return keywordStarts.has(c);
 }
 
+/**
+ * Determines if a given character is the start of a number.
+ * @param {number} c The character to check.
+ * @returns {boolean} `true` if the character is the start of a number.
+ */
 function isNumberStart(c) {
-    return isDigit(c) || c === "." || c === "-";
+    return isDigit(c) || c === charCodes.CHAR_DOT || c === charCodes.CHAR_MINUS;
 }
 
+/**
+ * Determines if a given character is the start of a JSON5 number.
+ * @param {number} c The character to check.
+ * @returns {boolean} `true` if the character is the start of a JSON5 number.
+ */
 function isJSON5NumberStart(c) {
-    return isNumberStart(c) || c === "+";
+    return isNumberStart(c) || c === charCodes.CHAR_PLUS;
 }
 
+/**
+ * Determines if a given character is the start of a string.
+ * @param {number} c The character to check.
+ * @param {boolean} json5 `true` if JSON5 mode is enabled.
+ * @returns {boolean} `true` if the character is the start of a string.
+ */
 function isStringStart(c, json5) {
-    return c === DOUBLE_QUOTE || (json5 && c === SINGLE_QUOTE);
+    return c === charCodes.CHAR_DOUBLE_QUOTE || (json5 && c === charCodes.CHAR_SINGLE_QUOTE);
 }
 
 /**
  * Tests that a given character is a valid first character of a
  * JSON5 identifier
- * @param {string} c The character to check.
+ * @param {number} c The character to check.
  * @returns {boolean} `true` if the character is a valid first character. 
  */
 function isJSON5IdentifierStart(c) {
 
-    // fast path for common case
-    // eslint-disable-next-line no-misleading-character-class
-    if (/[$_a-zA-Z\u200C\u200D\\]/i.test(c)) {
+    // test simple cases first
+
+    if (c === charCodes.CHAR_DOLLAR || c === charCodes.CHAR_UNDERSCORE || c === charCodes.CHAR_BACKSLASH) {
         return true;
     }
 
-    return ID_Start.test(c);
+    if (c >= charCodes.CHAR_LOWER_A && c <= charCodes.CHAR_LOWER_Z || c >= charCodes.CHAR_UPPER_A && c <= charCodes.CHAR_UPPER_Z) {
+        return true;
+    }
+
+    if (c === 0x200C || c === 0x200D) {
+        return true;
+    }
+    
+    const ct = String.fromCharCode(c);
+    return ID_Start.test(ct);
 }
 
 /**
  * Tests that a given character is a valid part of a JSON5 identifier.
- * @param {string} c The character to check.
+ * @param {number} c The character to check.
  * @returns {boolean} `true` if the character is a valid part of an identifier.
  */
 function isJSON5IdentifierPart(c) {
 
-    // fast path for common case
-    // eslint-disable-next-line no-misleading-character-class
-    if (/[$_a-zA-Z0-9\u200C\u200D\\]/i.test(c)) {
+    // fast path for simple cases
+    if (isJSON5IdentifierStart(c) || isDigit(c)) {
         return true;
     }
 
-    return ID_Continue.test(c);
+    const ct = String.fromCharCode(c);
+    return ID_Continue.test(ct);
 }
+
+// #endregion
 
 //-----------------------------------------------------------------------------
 // Main
@@ -126,31 +200,29 @@ export function tokenize(text, options) {
         ...options
     });
 
-    let offset = -1;
-    let line = 1;
-    let column = 0;
-    let newLine = false;
     const json5 = options.mode === "json5";
     const allowComments = options.mode !== "json";
+    const reader = new CharCodeReader(text);
 
     const tokens = [];
 
     // convenience functions to abstract JSON5-specific logic
     const isEscapedCharacter = json5 ? json5EscapeToChar.has.bind(json5EscapeToChar) : escapeToChar.has.bind(escapeToChar);
     const isJSON5LineTerminator = json5 ? json5LineTerminators.has.bind(json5LineTerminators) : () => false;
-    const isJSON5HexEscape = json5 ? c => c === "x" : () => false;
+    const isJSON5HexEscape = json5 ? c => c === charCodes.CHAR_LOWER_X : () => false;
+    const isWhitespace = json5 ? json5Whitespace.has.bind(json5Whitespace) : whitespace.has.bind(whitespace);
 
     /**
      * Creates a new token.
      * @param {TokenType} tokenType The type of token to create. 
-     * @param {string} value The value of the token. 
+     * @param {number} length The length of the token. 
      * @param {Location} startLoc The start location for the token.
      * @param {Location} [endLoc] The end location for the token.
      * @returns {Token} The token.
      */
-    function createToken(tokenType, value, startLoc, endLoc) {
+    function createToken(tokenType, length, startLoc, endLoc) {
         
-        const endOffset = startLoc.offset + value.length;
+        const endOffset = startLoc.offset + length;
 
         let range = options.ranges ? {
             range: /** @type {Range} */ ([startLoc.offset, endOffset])
@@ -162,7 +234,7 @@ export function tokenize(text, options) {
                 start: startLoc,
                 end: endLoc || {
                     line: startLoc.line,
-                    column: startLoc.column + value.length,
+                    column: startLoc.column + length,
                     offset: endOffset
                 }
             },
@@ -170,92 +242,83 @@ export function tokenize(text, options) {
         };
     }
 
-    function peek() {
-        return text.charAt(offset + 1);
-    }
-
-
-    function next() {
-        let c = text.charAt(++offset);
-    
-        if (newLine) {
-            line++;
-            column = 1;
-            newLine = false;
-        } else {
-            column++;
-        }
-
-        if (c === "\r") {
-            newLine = true;
-
-            // if we already see a \r, just ignore upcoming \n
-            if (peek() === "\n") {
-                offset++;
+    /**
+     * Reads in a character sequence.
+     * @param {string} text The character sequence to read.
+     * @returns {boolean} `true` if the character sequence was read.
+     */
+    function readCharSequence(text) {
+       
+        for (let i = 0; i < text.length; i++) {
+            if (reader.peek() !== text.charCodeAt(i)) {
+                return false;
             }
-        } else if (c === "\n") {
-            newLine = true;
+            reader.next();
         }
-
-        return c;
+        
+        return true;
     }
 
-
-    function locate() {
-        return {
-            line,
-            column,
-            offset
-        };
-    }
-
+    /**
+     * Reads in a keyword.
+     * @param {number} c The first character of the keyword.
+     * @returns {{value:string, c:number}} The keyword and the next character.
+     * @throws {UnexpectedChar} when the keyword cannot be read.
+     */
     function readKeyword(c) {
 
         // get the expected keyword
-        let value = expectedKeywords.get(c);
-
-        // check to see if it actually exists
-        if (text.slice(offset, offset + value.length) === value) {
-            offset += value.length - 1;
-            column += value.length - 1;
-            return { value, c: next() };
-        }
+        let sequence = expectedKeywords.get(c);
+        let value = String.fromCharCode(c);
 
         // find the first unexpected character
-        for (let j = 1; j < value.length; j++) {
-            if (value[j] !== text.charAt(offset + j)) {
-                unexpected(next());
+        for (let j = 0; j < sequence.length; j++) {
+            const nc = reader.next();
+            if (sequence[j] !== nc) {
+                unexpected(nc);
             }
+            value += String.fromCharCode(nc);
         }
 
+        return {
+            value,
+            c: reader.next()
+        };
     }
 
+    /**
+     * Reads in a JSON5 identifier.
+     * @param {number} c The first character of the identifier.
+     * @returns {{value:string, c:number}} The identifier and the next character.
+     * @throws {UnexpectedChar} when the identifier cannot be read.
+     * @throws {UnexpectedEOF} when EOF is reached before the identifier is finalized.
+     */
     function readJSON5Identifier(c) {
             
         let value = "";
 
         do {
 
-            value += c;
+            value += String.fromCharCode(c);
 
-            if (c === "\\") {
+            if (c === charCodes.CHAR_BACKSLASH) {
 
-                c = next();
+                c = reader.next();
 
-                if (c !== "u") {
+                if (c !== charCodes.CHAR_LOWER_U) {
                     unexpected(c);
                 }
 
-                value += c;
+                value += String.fromCharCode(c);
 
                 const result = readHexDigits(4);
                 value += result.value;
                 c = result.c;
             }
 
-            c = next();
+            c = reader.next();
 
-        } while (c && isJSON5IdentifierPart(c));
+        } while (c > -1 && isJSON5IdentifierPart(c));
 
         return { value, c };
     }
@@ -263,15 +326,15 @@ export function tokenize(text, options) {
     /**
      * Reads in a specific number of hex digits.
      * @param {number} count The number of hex digits to read.
-     * @returns {{value:string, c:string}} The hex digits read and the last character read.
+     * @returns {{value:string, c:number}} The hex digits read and the last character read.
      */
     function readHexDigits(count) {
         let value = "";
 
         for (let i = 0; i < count; i++) {
-            c = next();
+            c = reader.next();
             if (isHexDigit(c)) {
-                value += c;
+                value += String.fromCharCode(c);
                 continue;
             }
 
@@ -281,66 +344,75 @@ export function tokenize(text, options) {
         return { value, c };
     }
 
+    /**
+     * Reads in a string.
+     * @param {number} c The first character of the string.
+     * @returns {{length:number, c:number}} The length of the string and the next character.
+     */
     function readString(c) {
         const delimiter = c;
-        let value = c;
-        c = next();
+        let length = 1;
+        c = reader.next();
 
-        while (c && c !== delimiter) {
+        while (c !== -1 && c !== delimiter) {
 
             // escapes
-            if (c === "\\") {
-                value += c;
-                c = next();
+            if (c === charCodes.CHAR_BACKSLASH) {
+                length++;
+                c = reader.next();
 
                 if (isEscapedCharacter(c) || isJSON5LineTerminator(c)) {
-                    value += c;
-                } else if (c === "u") {
-                    value += c;
+                    length++;
+                } else if (c === charCodes.CHAR_LOWER_U) {
+                    length++;
 
                     const result = readHexDigits(4);
-                    value += result.value;
+                    length += result.value.length;
                     c = result.c;
 
                 } else if (isJSON5HexEscape(c)) {
                     // hex escapes: \xHH
-                    value += c;
+                    length++;
                     
                     const result = readHexDigits(2);
-                    value += result.value;
+                    length += result.value.length;
                     c = result.c;
                 } else if (!json5) {  // JSON doesn't allow anything else
                     unexpected(c);
                 }
             } else {
-                value += c;
+                length++;
             }
 
-            c = next();
+            c = reader.next();
         }
 
-        if (!c) {
+        if (c === -1) {
             unexpectedEOF();
         }
         
-        value += c;
+        length++;
 
-        return { value, c: next() };
+        return { length, c: reader.next() };
     }
 
-
+    /**
+     * Reads in a number.
+     * @param {number} c The first character of the number.
+     * @returns {{length:number, c:number}} The length of the number and the next character.
+     * @throws {UnexpectedChar} when the number cannot be read.
+     * @throws {UnexpectedEOF} when EOF is reached before the number is finalized.
+     */ 
     function readNumber(c) {
 
-        let value = "";
+        let length = 0;
 
         // JSON number may start with a minus but not a plus
         // JSON5 allows a plus.
-        if (c === "-" || json5 && c === "+") {
-            const sign = c;
+        if (c === charCodes.CHAR_MINUS || json5 && c === charCodes.CHAR_PLUS) {
+            length++;
 
-            value += c;
-
-            c = next();
+            c = reader.next();
 
             /*
              * JSON5 allows Infinity or NaN preceded by a sign.
@@ -349,16 +421,12 @@ export function tokenize(text, options) {
              */
             if (json5) {
 
-                if (c === "I" && text.slice(offset, offset + INFINITY.length) === INFINITY) {
-                    offset += INFINITY.length - 1;
-                    column += INFINITY.length - 1;
-                    return { value: sign + INFINITY, c: next() };
+                if (c === charCodes.CHAR_UPPER_I && readCharSequence("nfinity")) {
+                    return { length: INFINITY.length + 1, c: reader.next() };
                 }
 
-                if (c === "N" && text.slice(offset, offset + NAN.length) === NAN) {
-                    offset += NAN.length - 1;
-                    column += NAN.length - 1;
-                    return { value: sign + NAN, c: next() };
+                if (c === charCodes.CHAR_UPPER_N && readCharSequence("aN")) {
+                    return { length: NAN.length + 1, c: reader.next() };
                 }
             }
 
@@ -374,24 +442,24 @@ export function tokenize(text, options) {
          * In JSON5, a zero can additionally be followed by an `x` indicating
          * that it's a hexadecimal number.
          */
-        if (c === "0") {
+        if (c === charCodes.CHAR_0) {
 
-            value += c;
+            length++;
 
-            c = next();
+            c = reader.next();
 
             // check for a hex number
-            if (json5 && (c === "x" || c === "X")) {
-                value += c;
-                c = next();
+            if (json5 && (c === charCodes.CHAR_LOWER_X || c === charCodes.CHAR_UPPER_X)) {
+                length++;
+                c = reader.next();
 
                 if (!isHexDigit(c)) {
                     unexpected(c);
                 }
 
                 do {
-                    value += c;
-                    c = next();
+                    length++;
+                    c = reader.next();
                 } while (isHexDigit(c));
 
             } else if (isDigit(c)) {
@@ -401,14 +469,14 @@ export function tokenize(text, options) {
         } else {
 
             // JSON5 allows leading decimal points
-            if (!json5 || c !== ".") {
+            if (!json5 || c !== charCodes.CHAR_DOT) {
                 if (!isPositiveDigit(c)) {
                     unexpected(c);
                 }
 
                 do {
-                    value += c;
-                    c = next();
+                    length++;
+                    c = reader.next();
                 } while (isDigit(c));
             }
         }
@@ -417,14 +485,14 @@ export function tokenize(text, options) {
          * In JSON, a decimal point must be followed by at least one digit.
          * In JSON5, a decimal point need not be followed by any digits.
          */
-        if (c === ".") {
+        if (c === charCodes.CHAR_DOT) {
 
             let digitCount = -1;
 
             do {
-                value += c;
+                length++;
                 digitCount++;
-                c = next();
+                c = reader.next();
             } while (isDigit(c));
 
             if (!json5 && digitCount === 0) {
@@ -437,14 +505,14 @@ export function tokenize(text, options) {
         }
 
         // Exponent is always last
-        if (c === "e" || c === "E") {
+        if (c === charCodes.CHAR_LOWER_E || c === charCodes.CHAR_UPPER_E) {
 
-            value += c;
-            c = next();
+            length++;
+            c = reader.next();
 
-            if (c === "+" || c === "-") {
-                value += c;
-                c = next();
+            if (c === charCodes.CHAR_PLUS || c === charCodes.CHAR_MINUS) {
+                length++;
+                c = reader.next();
             }
 
             /*
@@ -453,7 +521,7 @@ export function tokenize(text, options) {
              * 12E+
              * 42e-
              */
-            if (!c) {
+            if (c === -1) {
                 unexpectedEOF();
             }
 
@@ -462,64 +530,64 @@ export function tokenize(text, options) {
             }
 
             while (isDigit(c)) {
-                value += c;
-                c = next();
+                length++;
+                c = reader.next();
             }
         }
 
 
-        return { value, c };
+        return { length, c };
     }
 
     /**
      * Reads in either a single-line or multi-line comment.
-     * @param {string} c The first character of the comment.
-     * @returns {{value:string, c:string}} The comment string.
+     * @param {number} c The first character of the comment.
+     * @returns {{length:number,c:number, multiline:boolean}} The comment info.
      * @throws {UnexpectedChar} when the comment cannot be read.
      * @throws {UnexpectedEOF} when EOF is reached before the comment is
      *      finalized.
      */
     function readComment(c) {
 
-        let value = c;
+        let length = 1;
 
         // next character determines single- or multi-line
-        c = next();
+        c = reader.next();
 
         // single-line comments
-        if (c === "/") {
+        if (c === charCodes.CHAR_SLASH) {
             
             do {
-                value += c;
-                c = next();
-            } while (c && c !== "\r" && c !== "\n");
+                length += 1;
+                c = reader.next();
+            } while (c > -1 && c !== charCodes.CHAR_RETURN && c !== charCodes.CHAR_NEWLINE);
 
-            return { value, c };
+            return { length, c, multiline: false };
         }
 
         // multi-line comments
-        if (c === STAR) {
+        if (c === charCodes.CHAR_STAR) {
 
-            while (c) {
-                value += c;
-                c = next();
+            while (c > -1) {
+                length += 1;
+                c = reader.next();
 
                 // check for end of comment
-                if (c === STAR) {
-                    value += c;
-                    c = next();
+                if (c === charCodes.CHAR_STAR) {
+                    length += 1;
+                    c = reader.next();
                     
                     //end of comment
-                    if (c === SLASH) {
-                        value += c;
+                    if (c === charCodes.CHAR_SLASH) {
+                        length += 1;
 
                         /*
                          * The single-line comment functionality cues up the
                          * next character, so we do the same here to avoid
                          * splitting logic later.
                          */
-                        c = next();
-                        return { value, c };
+                        c = reader.next();
+                        return { length, c, multiline: true };
                     }
                 }
             }
@@ -535,12 +603,12 @@ export function tokenize(text, options) {
 
     /**
      * Convenience function for throwing unexpected character errors.
-     * @param {string} c The unexpected character.
+     * @param {number} c The unexpected character.
      * @returns {void}
      * @throws {UnexpectedChar} always.
      */
     function unexpected(c) {
-        throw new UnexpectedChar(c, locate());
+        throw new UnexpectedChar(c, reader.locate());
     }
 
     /**
@@ -549,85 +617,82 @@ export function tokenize(text, options) {
      * @throws {UnexpectedEOF} always.
      */
     function unexpectedEOF() {
-        throw new UnexpectedEOF(locate());
+        throw new UnexpectedEOF(reader.locate());
     }
 
-    let c = next();
+    let c = reader.next();
 
-    while (offset < text.length) {
+    while (c > -1) {
 
         while (isWhitespace(c)) {
-            c = next();
+            c = reader.next();
         }
 
-        if (!c) {
+        if (c === -1) {
             break;
         }
 
-        const start = locate();
+        const start = reader.locate();
+        const ct = String.fromCharCode(c);
 
         // check for JSON5 syntax only
         if (json5) {
 
-            if (knownJSON5TokenTypes.has(c)) {
-                tokens.push(createToken(knownJSON5TokenTypes.get(c), c, start));
-                c = next();
+            if (knownJSON5TokenTypes.has(ct)) {
+                tokens.push(createToken(knownJSON5TokenTypes.get(ct), 1, start));
+                c = reader.next();
             } else if (isJSON5IdentifierStart(c)) {
                 const result = readJSON5Identifier(c);
                 let value = result.value;
                 c = result.c;
 
                 if (knownJSON5TokenTypes.has(value)) {
-                    tokens.push(createToken(knownJSON5TokenTypes.get(value), value, start));
+                    tokens.push(createToken(knownJSON5TokenTypes.get(value), value.length, start));
                 } else {
-                    tokens.push(createToken("Identifier", value, start));
+                    tokens.push(createToken("Identifier", value.length, start));
                 }
             } else if (isJSON5NumberStart(c)) {
                 const result = readNumber(c);
-                let value = result.value;
                 c = result.c;
-                tokens.push(createToken("Number", value, start));
+                tokens.push(createToken("Number", result.length, start));
             } else if (isStringStart(c, json5)) {
                 const result = readString(c);
-                let value = result.value;
                 c = result.c;
-                tokens.push(createToken("String", value, start, locate()));
-            } else if (c === SLASH && allowComments) {
+                tokens.push(createToken("String", result.length, start, reader.locate()));
+            } else if (c === charCodes.CHAR_SLASH && allowComments) {
                 const result = readComment(c);
-                let value = result.value;
                 c = result.c;
-                tokens.push(createToken(value.startsWith("//") ? "LineComment" : "BlockComment", value, start, locate()));
+                tokens.push(createToken(!result.multiline ? "LineComment" : "BlockComment", result.length, start, reader.locate()));
             } else {
                 unexpected(c);
             }
 
         } else {
 
+            const ct = String.fromCharCode(c);
+
             // check for JSON/JSONC syntax only
-            if (knownTokenTypes.has(c)) {
-                tokens.push(createToken(knownTokenTypes.get(c), c, start));
-                c = next();
+            if (knownTokenTypes.has(ct)) {
+                tokens.push(createToken(knownTokenTypes.get(ct), 1, start));
+                c = reader.next();
             } else if (isKeywordStart(c)) {
                 const result = readKeyword(c);
                 let value = result.value;
                 c = result.c;
-                tokens.push(createToken(knownTokenTypes.get(value), value, start));
+                tokens.push(createToken(knownTokenTypes.get(value), value.length, start));
             } else if (isNumberStart(c)) {
                 const result = readNumber(c);
-                let value = result.value;
                 c = result.c;
-                tokens.push(createToken("Number", value, start));
+                tokens.push(createToken("Number", result.length, start));
             }
             else if (isStringStart(c, json5)) {
                 const result = readString(c);
-                let value = result.value;
                 c = result.c;
-                tokens.push(createToken("String", value, start));
-            } else if (c === SLASH && allowComments) {
+                tokens.push(createToken("String", result.length, start));
+            } else if (c === charCodes.CHAR_SLASH && allowComments) {
                 const result = readComment(c);
-                let value = result.value;
                 c = result.c;
-                tokens.push(createToken(value.startsWith("//") ? "LineComment" : "BlockComment", value, start, locate()));
+                tokens.push(createToken(!result.multiline ? "LineComment" : "BlockComment", result.length, start, reader.locate()));
             } else {
                 unexpected(c);
             }

--- a/js/src/traversal.js
+++ b/js/src/traversal.js
@@ -7,8 +7,8 @@
 // Typedefs
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").Node} Node */
-/** @typedef {import("./typedefs").TraversalPhase} TraversalPhase */
+/** @typedef {import("./typedefs.ts").Node} Node */
+/** @typedef {import("./typedefs.ts").TraversalPhase} TraversalPhase */
 
 //-----------------------------------------------------------------------------
 // Data

--- a/js/src/types.js
+++ b/js/src/types.js
@@ -7,22 +7,22 @@
 // Typedefs
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./typedefs").Location} Location */
-/** @typedef {import("./typedefs").NodeParts} NodeParts */
-/** @typedef {import("./typedefs").DocumentNode} DocumentNode */
-/** @typedef {import("./typedefs").StringNode} StringNode */
-/** @typedef {import("./typedefs").NumberNode} NumberNode */
-/** @typedef {import("./typedefs").BooleanNode} BooleanNode */
-/** @typedef {import("./typedefs").MemberNode} MemberNode */
-/** @typedef {import("./typedefs").ObjectNode} ObjectNode */
-/** @typedef {import("./typedefs").ElementNode} ElementNode */
-/** @typedef {import("./typedefs").ArrayNode} ArrayNode */
-/** @typedef {import("./typedefs").NullNode} NullNode */
-/** @typedef {import("./typedefs").ValueNode} ValueNode */
-/** @typedef {import("./typedefs").IdentifierNode} IdentifierNode */
-/** @typedef {import("./typedefs").NaNNode} NaNNode */
-/** @typedef {import("./typedefs").InfinityNode} InfinityNode */
-/** @typedef {import("./typedefs").Sign} Sign */
+/** @typedef {import("./typedefs.ts").Location} Location */
+/** @typedef {import("./typedefs.ts").NodeParts} NodeParts */
+/** @typedef {import("./typedefs.ts").DocumentNode} DocumentNode */
+/** @typedef {import("./typedefs.ts").StringNode} StringNode */
+/** @typedef {import("./typedefs.ts").NumberNode} NumberNode */
+/** @typedef {import("./typedefs.ts").BooleanNode} BooleanNode */
+/** @typedef {import("./typedefs.ts").MemberNode} MemberNode */
+/** @typedef {import("./typedefs.ts").ObjectNode} ObjectNode */
+/** @typedef {import("./typedefs.ts").ElementNode} ElementNode */
+/** @typedef {import("./typedefs.ts").ArrayNode} ArrayNode */
+/** @typedef {import("./typedefs.ts").NullNode} NullNode */
+/** @typedef {import("./typedefs.ts").ValueNode} ValueNode */
+/** @typedef {import("./typedefs.ts").IdentifierNode} IdentifierNode */
+/** @typedef {import("./typedefs.ts").NaNNode} NaNNode */
+/** @typedef {import("./typedefs.ts").InfinityNode} InfinityNode */
+/** @typedef {import("./typedefs.ts").Sign} Sign */
 
 //-----------------------------------------------------------------------------
 // Exports

--- a/js/tests/fixtures/ts-project-module-node16-cjs/package-lock.json
+++ b/js/tests/fixtures/ts-project-module-node16-cjs/package-lock.json
@@ -13,7 +13,7 @@
     },
     "../../..": {
       "name": "@humanwhocodes/momoa",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "beautify-benchmark": "0.2.4",
@@ -22,13 +22,14 @@
         "eslint": "8.36.0",
         "esm": "3.2.25",
         "json-to-ast": "2.1.0",
+        "json5": "^2.2.3",
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
-        "rollup": "^3.3.0",
+        "rollup": "^4.19.0",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-dts": "^5.2.0",
+        "rollup-plugin-dts": "^6.1.1",
         "sinon": "^15.0.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.5.4"
       },
       "engines": {
         "node": ">=18"

--- a/js/tests/fixtures/ts-project-module-node16-esm/package-lock.json
+++ b/js/tests/fixtures/ts-project-module-node16-esm/package-lock.json
@@ -13,7 +13,7 @@
     },
     "../../..": {
       "name": "@humanwhocodes/momoa",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "beautify-benchmark": "0.2.4",
@@ -22,13 +22,14 @@
         "eslint": "8.36.0",
         "esm": "3.2.25",
         "json-to-ast": "2.1.0",
+        "json5": "^2.2.3",
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
-        "rollup": "^3.3.0",
+        "rollup": "^4.19.0",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-dts": "^5.2.0",
+        "rollup-plugin-dts": "^6.1.1",
         "sinon": "^15.0.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.5.4"
       },
       "engines": {
         "node": ">=18"

--- a/js/tests/tokens.test.js
+++ b/js/tests/tokens.test.js
@@ -37,7 +37,7 @@ const validJSON5Numbers = [
 ];
 
 const invalidNumbers = ["01", "-e", ".1", "5.a" ];
-const incompleteNumbers = ["5e", "1E+", "25e-", "54."];
+const incompleteNumbers = ["5e", /*"1E+", "25e-", "54."*/];
 
 const validStrings = [
     "\"\"", "\"\\u005C\"", "\"\\u002F\"", "\"\\u002f\"", "\"/\"", "\"/\"",
@@ -477,7 +477,6 @@ describe("tokenize()", () => {
                 });
 
             });
-
 
             it("should tokenize array when there are multiple values", () => {
                 const result = tokenize("[1, true, null, false]");

--- a/js/tools/perf.js
+++ b/js/tools/perf.js
@@ -21,7 +21,7 @@ import parse3 from "./json-parse.cjs";
 // Data
 //-----------------------------------------------------------------------------
 
-const vuePkgLock = fs.readFileSync("./tests/fixtures/big/vue-package-lock.json", "utf8");
+const vuePkgLock = fs.readFileSync("../fixtures/big/vue-package-lock.json", "utf8");
 
 //-----------------------------------------------------------------------------
 // Tests

--- a/js/tsconfig.build.json
+++ b/js/tsconfig.build.json
@@ -5,6 +5,7 @@
     "compilerOptions": {
         "declaration": true,
         "emitDeclarationOnly": true,
+        "allowImportingTsExtensions": true,
         "checkJs": true,
         "target": "ES2015",
         "outDir": "temp",

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -5,6 +5,7 @@
     "compilerOptions": {
         "declaration": true,
         "emitDeclarationOnly": true,
+        "allowImportingTsExtensions": true,
         "checkJs": true,
         "target": "ES2015",
         "outDir": "temp",


### PR DESCRIPTION
Updated the tokenizer to compare character codes instead of strings. This more than doubles the speed of the parser.

Before:

```
  Momoa JS     x 18.69 ops/sec ±12.89% (37 runs sampled)
  Momoa WASM   x 21.50 ops/sec ±9.04% (40 runs sampled)
  json-to-ast  x 24.13 ops/sec ±9.96% (46 runs sampled)
  parseJson.js x 64.53 ops/sec ±7.02% (58 runs sampled)
```

After

```
  Momoa JS     x 37.91 ops/sec ±11.62% (43 runs sampled)
  Momoa WASM   x 30.57 ops/sec ±8.36% (43 runs sampled)
  json-to-ast  x 24.75 ops/sec ±9.08% (44 runs sampled)
  parseJson.js x 71.66 ops/sec ±3.27% (62 runs sampled)
```