### PR TITLE
fix(types): fix FilterPredicate type

### DIFF
--- a/js/src/traversal.js
+++ b/js/src/traversal.js
@@ -96,9 +96,9 @@ export function traverse(root, visitor) {
 
 /**
  * @callback FilterPredicate
- * @param {Node} node
+ * @param {{node: Node, parent?: Node, phase: TraversalPhase}} item
  * @param {number} index
- * @param {Array<Node>} array
+ * @param {Array<{node: Node, parent?: Node, phase: TraversalPhase}>} array
  * @returns {boolean}
  */
 
@@ -107,10 +107,11 @@ export function traverse(root, visitor) {
  * @param {Node} root The root AST node to traverse. 
  * @param {FilterPredicate} [filter] A filter function to determine which steps to
  *      return;
- * @returns {IterableIterator<{node:Node,parent:Node|undefined,phase:TraversalPhase}>} An iterator over the AST.  
+ * @returns {IterableIterator<{node: Node, parent?: Node, phase: TraversalPhase}>} An iterator over the AST.  
  */
 export function iterator(root, filter = () => true) {
 
+    /** @type {Array<{node: Node, parent?: Node, phase: TraversalPhase}>} */
     const traversal = [];
 
     traverse(root, {

--- a/js/tests/traversal.test.js
+++ b/js/tests/traversal.test.js
@@ -180,6 +180,16 @@ describe("iterator()", () => {
                 ]);
             });
 
+            it("should iterate using a filter", () => {
+                const root = t.document(t.identifier("foo"));
+                const steps = [...iterator(root, ({node}) => node.type === "Document")];
+
+                expect(steps).to.deep.equal([
+                    { node: root, parent: undefined, phase: "enter" },
+                    { node: root, parent: undefined, phase: "exit" }
+                ]);
+            });
+
         });
     });
 });


### PR DESCRIPTION
This changes the type of `FilterPredicate` so that it aligns with reality.

* * *

Background: the `filter` param to `iterator(filter)` was not being called with `[Node, number, Node[]]` as per the `FilterPredicate` type, but rather `[{node: Node, parent?: Node, phase: TraversalPhase}, number, {node: Node, parent?: Node, phase: TraversalPhase}[]]`.

This changes the type to match what it's actually called with.  Changing the function to match the type would be a breaking change (and probably kind of weird to implement).