### PR TITLE
fix(types): export LocationRange

### DIFF
--- a/js/src/tokens.js
+++ b/js/src/tokens.js
@@ -27,6 +27,7 @@ import * as charCodes from "./char-codes.js";
 /** @typedef {import("./typedefs.ts").Range} Range */
 /** @typedef {import("./typedefs.ts").Token} Token */
 /** @typedef {import("./typedefs.js").LocationRange} LocationRange */
+/** @typedef {import("./typedefs.js").ContainerNode} ContainerNode */
 /** @typedef {import("./typedefs.ts").TokenType} TokenType */
 /** @typedef {import("./typedefs.ts").TokenizeOptions} TokenizeOptions */
 

--- a/js/src/tokens.js
+++ b/js/src/tokens.js
@@ -26,6 +26,7 @@ import * as charCodes from "./char-codes.js";
 /** @typedef {import("./typedefs.ts").Location} Location */
 /** @typedef {import("./typedefs.ts").Range} Range */
 /** @typedef {import("./typedefs.ts").Token} Token */
+/** @typedef {import("./typedefs.js").LocationRange} LocationRange */
 /** @typedef {import("./typedefs.ts").TokenType} TokenType */
 /** @typedef {import("./typedefs.ts").TokenizeOptions} TokenizeOptions */
 


### PR DESCRIPTION
`Token` contains a `LocationRange`, but `LocationRange` was not previously exported.
