### PR TITLE
fix(types): Export LocationRange and ContainerNode

### DIFF
--- a/js/rollup.types.js
+++ b/js/rollup.types.js
@@ -1,12 +1,21 @@
 import dts from "rollup-plugin-dts";
 
+// types that aren't exported by default by should be
+const typeExports = [
+    "ContainerNode",
+    "LocationRange"
+];
+
+const footer = `export type { ${typeExports.join(", ")} };`;
+
 export default [
     {
         input: "temp/momoa.d.ts",
         output: [
             {
                 file: "dist/momoa.d.ts",
-                format: "esm"
+                format: "esm",
+                footer
             }
         ],
         plugins: [
@@ -18,7 +27,8 @@ export default [
         output: [
             {
                 file: "dist/momoa.d.cts",
-                format: "commonjs"
+                format: "commonjs",
+                footer
             }
         ],
         plugins: [


### PR DESCRIPTION
This exports additional types from Momoa that aren't otherwise exported automatically.

Closes #134

@boneskull Can you check to see if this works for you?