### PR TITLE
fix: mark `allowTrailingCommas` as optional

### DIFF
--- a/js/src/typedefs.ts
+++ b/js/src/typedefs.ts
@@ -1,4 +1,3 @@
-
 //-----------------------------------------------------------------------------
 // Options
 //-----------------------------------------------------------------------------
@@ -27,44 +26,42 @@ export type Sign = "+" | "-" | "";
  * Tokenization options.
  */
 export interface TokenizeOptions {
+	/**
+	 * The mode to tokenize in.
+	 */
+	readonly mode: Mode;
 
-    /**
-     * The mode to tokenize in.
-     */
-    readonly mode: Mode;
-
-    /**
-     * When true, includes the `range` key on each token.
-     */
-    readonly ranges: boolean;
+	/**
+	 * When true, includes the `range` key on each token.
+	 */
+	readonly ranges: boolean;
 }
 
 /**
  * Parse options.
  */
 export interface ParseOptions {
+	/**
+	 * The mode to parse in.
+	 */
+	readonly mode: Mode;
 
-    /**
-     * The mode to parse in.
-     */
-    readonly mode: Mode;
+	/**
+	 * When true, includes the `range` key on each node and token.
+	 */
+	readonly ranges: boolean;
 
-    /**
-     * When true, includes the `range` key on each node and token.
-     */
-    readonly ranges: boolean;
+	/**
+	 * When true, includes the `tokens` key on the document node containing
+	 * all of the tokens used during parsing.
+	 */
+	readonly tokens: boolean;
 
-    /**
-     * When true, includes the `tokens` key on the document node containing
-     * all of the tokens used during parsing.
-     */
-    readonly tokens: boolean;
-
-    /**
-     * When true, allows trailing commas in arrays and objects. Defaults to
-     * false for JSON and JSONC modes, and true for JSON5 mode.
-     */
-    readonly allowTrailingCommas: boolean;
+	/**
+	 * When true, allows trailing commas in arrays and objects. Defaults to
+	 * false for JSON and JSONC modes, and true for JSON5 mode.
+	 */
+	readonly allowTrailingCommas?: boolean;
 }
 
 //-----------------------------------------------------------------------------
@@ -72,112 +69,110 @@ export interface ParseOptions {
 //-----------------------------------------------------------------------------
 
 export interface Node {
-    type: string;
-    loc: LocationRange;
-    range?: Range;
+	type: string;
+	loc: LocationRange;
+	range?: Range;
 }
 
 /**
  * The root node of a JSON document.
  */
 export interface DocumentNode extends Node {
-    type: "Document";
-    body: ValueNode;
-    tokens?: Array<Token>;
+	type: "Document";
+	body: ValueNode;
+	tokens?: Array<Token>;
 }
 
 export interface NullNode extends Node {
-    type: "Null";
+	type: "Null";
 }
 
 interface LiteralNode<T> extends Node {
-    value: T;
+	value: T;
 }
 
 /**
  * Represents a JSON5 NaN value.
  */
 export interface NaNNode extends Node {
-    type: "NaN";
-    sign: Sign;
+	type: "NaN";
+	sign: Sign;
 }
 
 /**
  * Represents a JSON5 Infinity value.
  */
 export interface InfinityNode extends Node {
-    type: "Infinity";
-    sign: Sign;
+	type: "Infinity";
+	sign: Sign;
 }
 
 /**
  * Represents a JSON identifier.
  */
 export interface IdentifierNode extends Node {
-    type: "Identifier";
-    name: string;
+	type: "Identifier";
+	name: string;
 }
 
 /**
  * Represents a JSON string.
  */
 export interface StringNode extends LiteralNode<string> {
-    type: "String";
+	type: "String";
 }
 
 /**
  * Represents a JSON number.
  */
 export interface NumberNode extends LiteralNode<number> {
-    type: "Number";
+	type: "Number";
 }
 
 /**
  * Represents a JSON boolean.
  */
 export interface BooleanNode extends LiteralNode<boolean> {
-    type: "Boolean";
+	type: "Boolean";
 }
 
 /**
  * Represents an element of a JSON array.
  */
 export interface ElementNode extends Node {
-    type: "Element";
-    value: ValueNode;
+	type: "Element";
+	value: ValueNode;
 }
 
 /**
  * Represents a JSON array.
  */
 export interface ArrayNode extends Node {
-    type: "Array";
-    elements: Array<ElementNode>;
+	type: "Array";
+	elements: Array<ElementNode>;
 }
 
 /**
  * Represents a member of a JSON object.
  */
 export interface MemberNode extends Node {
-    type: "Member";
-    name: StringNode | IdentifierNode;
-    value: ValueNode;
+	type: "Member";
+	name: StringNode | IdentifierNode;
+	value: ValueNode;
 }
 
 /**
  * Represents a JSON object.
  */
 export interface ObjectNode extends Node {
-    type: "Object";
-    members: Array<MemberNode>;
+	type: "Object";
+	members: Array<MemberNode>;
 }
 
 /**
  * Any node that represents a JSON value.
  */
-export type ValueNode = ArrayNode | ObjectNode | 
-    BooleanNode | StringNode | NumberNode | NullNode |
-    NaNNode | InfinityNode;
+export type ValueNode = ArrayNode | ObjectNode | BooleanNode | StringNode | NumberNode | NullNode | NaNNode | InfinityNode;
 
 /**
  * Any node that represents the container for a JSON value.
@@ -198,8 +193,8 @@ export type AnyNode = ValueNode | ContainerNode | JSON5ExtensionNode;
  * Additional information about an AST node.
  */
 export interface NodeParts {
-    loc?: LocationRange;
-    range?: Range;
+	loc?: LocationRange;
+	range?: Range;
 }
 
 //-----------------------------------------------------------------------------
@@ -209,13 +204,7 @@ export interface NodeParts {
 /**
  * Values that can be represented in JSON.
  */
-export type JSONValue =
-    | Array<JSONValue>
-    | boolean
-    | number
-    | string
-    | { [property: string]: JSONValue }
-    | null;
+export type JSONValue = Array<JSONValue> | boolean | number | string | { [property: string]: JSONValue } | null;
 
 //-----------------------------------------------------------------------------
 // Tokens
@@ -225,17 +214,30 @@ export type JSONValue =
  * A token used to during JSON parsing.
  */
 export interface Token {
-    type: TokenType;
-    loc: LocationRange;
-    range?: Range;
+	type: TokenType;
+	loc: LocationRange;
+	range?: Range;
 }
 
 /**
  * The type of token.
  */
-export type TokenType = "Number" | "String" | "Boolean" | "Colon" | "LBrace" |
-    "RBrace" | "RBracket" | "LBracket" | "Comma" | "Null" | "LineComment" |
-    "BlockComment" | "NaN" | "Infinity" | "Identifier";
+export type TokenType =
+	| "Number"
+	| "String"
+	| "Boolean"
+	| "Colon"
+	| "LBrace"
+	| "RBrace"
+	| "RBracket"
+	| "LBracket"
+	| "Comma"
+	| "Null"
+	| "LineComment"
+	| "BlockComment"
+	| "NaN"
+	| "Infinity"
+	| "Identifier";
 
 //-----------------------------------------------------------------------------
 // Location Related
@@ -245,17 +247,17 @@ export type TokenType = "Number" | "String" | "Boolean" | "Colon" | "LBrace" |
  * The start and stop location for a token or node inside the source text.
  */
 export interface LocationRange {
-    start: Location;
-    end: Location;
+	start: Location;
+	end: Location;
 }
 
 /**
  * A cursor location inside the source text.
  */
 export interface Location {
-    line: number;
-    column: number;
-    offset: number;
+	line: number;
+	column: number;
+	offset: number;
 }
 
 /**

--- a/js/src/typedefs.ts
+++ b/js/src/typedefs.ts
@@ -64,7 +64,7 @@ export interface ParseOptions {
      * When true, allows trailing commas in arrays and objects. Defaults to
      * false for JSON and JSONC modes, and true for JSON5 mode.
      */
-    readonly allowTrailingCommas: boolean;
+    readonly allowTrailingCommas?: boolean;
 }
 
 //-----------------------------------------------------------------------------

--- a/js/src/typedefs.ts
+++ b/js/src/typedefs.ts
@@ -1,3 +1,4 @@
+
 //-----------------------------------------------------------------------------
 // Options
 //-----------------------------------------------------------------------------
@@ -26,42 +27,44 @@ export type Sign = "+" | "-" | "";
  * Tokenization options.
  */
 export interface TokenizeOptions {
-	/**
-	 * The mode to tokenize in.
-	 */
-	readonly mode: Mode;
 
-	/**
-	 * When true, includes the `range` key on each token.
-	 */
-	readonly ranges: boolean;
+    /**
+     * The mode to tokenize in.
+     */
+    readonly mode: Mode;
+
+    /**
+     * When true, includes the `range` key on each token.
+     */
+    readonly ranges: boolean;
 }
 
 /**
  * Parse options.
  */
 export interface ParseOptions {
-	/**
-	 * The mode to parse in.
-	 */
-	readonly mode: Mode;
 
-	/**
-	 * When true, includes the `range` key on each node and token.
-	 */
-	readonly ranges: boolean;
+    /**
+     * The mode to parse in.
+     */
+    readonly mode: Mode;
 
-	/**
-	 * When true, includes the `tokens` key on the document node containing
-	 * all of the tokens used during parsing.
-	 */
-	readonly tokens: boolean;
+    /**
+     * When true, includes the `range` key on each node and token.
+     */
+    readonly ranges: boolean;
 
-	/**
-	 * When true, allows trailing commas in arrays and objects. Defaults to
-	 * false for JSON and JSONC modes, and true for JSON5 mode.
-	 */
-	readonly allowTrailingCommas?: boolean;
+    /**
+     * When true, includes the `tokens` key on the document node containing
+     * all of the tokens used during parsing.
+     */
+    readonly tokens: boolean;
+
+    /**
+     * When true, allows trailing commas in arrays and objects. Defaults to
+     * false for JSON and JSONC modes, and true for JSON5 mode.
+     */
+    readonly allowTrailingCommas: boolean;
 }
 
 //-----------------------------------------------------------------------------
@@ -69,110 +72,112 @@ export interface ParseOptions {
 //-----------------------------------------------------------------------------
 
 export interface Node {
-	type: string;
-	loc: LocationRange;
-	range?: Range;
+    type: string;
+    loc: LocationRange;
+    range?: Range;
 }
 
 /**
  * The root node of a JSON document.
  */
 export interface DocumentNode extends Node {
-	type: "Document";
-	body: ValueNode;
-	tokens?: Array<Token>;
+    type: "Document";
+    body: ValueNode;
+    tokens?: Array<Token>;
 }
 
 export interface NullNode extends Node {
-	type: "Null";
+    type: "Null";
 }
 
 interface LiteralNode<T> extends Node {
-	value: T;
+    value: T;
 }
 
 /**
  * Represents a JSON5 NaN value.
  */
 export interface NaNNode extends Node {
-	type: "NaN";
-	sign: Sign;
+    type: "NaN";
+    sign: Sign;
 }
 
 /**
  * Represents a JSON5 Infinity value.
  */
 export interface InfinityNode extends Node {
-	type: "Infinity";
-	sign: Sign;
+    type: "Infinity";
+    sign: Sign;
 }
 
 /**
  * Represents a JSON identifier.
  */
 export interface IdentifierNode extends Node {
-	type: "Identifier";
-	name: string;
+    type: "Identifier";
+    name: string;
 }
 
 /**
  * Represents a JSON string.
  */
 export interface StringNode extends LiteralNode<string> {
-	type: "String";
+    type: "String";
 }
 
 /**
  * Represents a JSON number.
  */
 export interface NumberNode extends LiteralNode<number> {
-	type: "Number";
+    type: "Number";
 }
 
 /**
  * Represents a JSON boolean.
  */
 export interface BooleanNode extends LiteralNode<boolean> {
-	type: "Boolean";
+    type: "Boolean";
 }
 
 /**
  * Represents an element of a JSON array.
  */
 export interface ElementNode extends Node {
-	type: "Element";
-	value: ValueNode;
+    type: "Element";
+    value: ValueNode;
 }
 
 /**
  * Represents a JSON array.
  */
 export interface ArrayNode extends Node {
-	type: "Array";
-	elements: Array<ElementNode>;
+    type: "Array";
+    elements: Array<ElementNode>;
 }
 
 /**
  * Represents a member of a JSON object.
  */
 export interface MemberNode extends Node {
-	type: "Member";
-	name: StringNode | IdentifierNode;
-	value: ValueNode;
+    type: "Member";
+    name: StringNode | IdentifierNode;
+    value: ValueNode;
 }
 
 /**
  * Represents a JSON object.
  */
 export interface ObjectNode extends Node {
-	type: "Object";
-	members: Array<MemberNode>;
+    type: "Object";
+    members: Array<MemberNode>;
 }
 
 /**
  * Any node that represents a JSON value.
  */
-export type ValueNode = ArrayNode | ObjectNode | BooleanNode | StringNode | NumberNode | NullNode | NaNNode | InfinityNode;
+export type ValueNode = ArrayNode | ObjectNode | 
+    BooleanNode | StringNode | NumberNode | NullNode |
+    NaNNode | InfinityNode;
 
 /**
  * Any node that represents the container for a JSON value.
@@ -193,8 +198,8 @@ export type AnyNode = ValueNode | ContainerNode | JSON5ExtensionNode;
  * Additional information about an AST node.
  */
 export interface NodeParts {
-	loc?: LocationRange;
-	range?: Range;
+    loc?: LocationRange;
+    range?: Range;
 }
 
 //-----------------------------------------------------------------------------
@@ -204,7 +209,13 @@ export interface NodeParts {
 /**
  * Values that can be represented in JSON.
  */
-export type JSONValue = Array<JSONValue> | boolean | number | string | { [property: string]: JSONValue } | null;
+export type JSONValue =
+    | Array<JSONValue>
+    | boolean
+    | number
+    | string
+    | { [property: string]: JSONValue }
+    | null;
 
 //-----------------------------------------------------------------------------
 // Tokens
@@ -214,30 +225,17 @@ export type JSONValue = Array<JSONValue> | boolean | number | string | { [proper
  * A token used to during JSON parsing.
  */
 export interface Token {
-	type: TokenType;
-	loc: LocationRange;
-	range?: Range;
+    type: TokenType;
+    loc: LocationRange;
+    range?: Range;
 }
 
 /**
  * The type of token.
  */
-export type TokenType =
-	| "Number"
-	| "String"
-	| "Boolean"
-	| "Colon"
-	| "LBrace"
-	| "RBrace"
-	| "RBracket"
-	| "LBracket"
-	| "Comma"
-	| "Null"
-	| "LineComment"
-	| "BlockComment"
-	| "NaN"
-	| "Infinity"
-	| "Identifier";
+export type TokenType = "Number" | "String" | "Boolean" | "Colon" | "LBrace" |
+    "RBrace" | "RBracket" | "LBracket" | "Comma" | "Null" | "LineComment" |
+    "BlockComment" | "NaN" | "Infinity" | "Identifier";
 
 //-----------------------------------------------------------------------------
 // Location Related
@@ -247,17 +245,17 @@ export type TokenType =
  * The start and stop location for a token or node inside the source text.
  */
 export interface LocationRange {
-	start: Location;
-	end: Location;
+    start: Location;
+    end: Location;
 }
 
 /**
  * A cursor location inside the source text.
  */
 export interface Location {
-	line: number;
-	column: number;
-	offset: number;
+    line: number;
+    column: number;
+    offset: number;
 }
 
 /**


### PR DESCRIPTION
When updating from `3.0.1` to  `3.3.1`, I noticed a breaking change was introduced in https://github.com/humanwhocodes/momoa/pull/136, specifically with the TypeScript type of `ParseOptions.allowTrailingCommas`.
```bash
C:/git/cli/src/json/schema.ts:105:27
 '{ mode: "json"; ranges: false; tokens: false; }' but required in type 'ParseOptions$1'.

105   const ast = parse(json, { mode: "json", ranges: false, tokens: false });
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/@humanwhocodes/momoa/dist/momoa.d.ts:66:14
    66     readonly allowTrailingCommas: boolean;
                    ~~~~~~~~~~~~~~~~~~~
    'allowTrailingCommas' is declared here.
```
This PR updates `ParseOptions.allowTrailingCommas` to be optional, preventing the introduction of a breaking change.