### PR TITLE
fix: Ensure numeric property keys are a syntax error

### DIFF
--- a/js/src/parse.js
+++ b/js/src/parse.js
@@ -401,6 +401,11 @@ export function parse(text, options) {
 
         const token = tokenizer.token;
 
+        // check for -NaN, +NaN, -Infinity, +Infinity, and any number
+        if (json5 && tokenType === tt.Number && /[+\-0-9]/.test(text[token.loc.start.offset])) {
+            throw new UnexpectedToken(token);
+        }
+
         // TODO: Clean this up a bit
         let key = tokenType === tt.String
             ? /** @type {StringNode} */ (createLiteralNode(tokenType))

--- a/js/tests/parse.test.js
+++ b/js/tests/parse.test.js
@@ -154,6 +154,45 @@ describe("parse()", () => {
                         }).to.throw("Unexpected token Number found.");
                     });
 
+                    it("should throw an error when 123 is used as a property key", () => {
+                        const text = "{ 123: 1 }";
+
+                        expect(() => {
+                            parse(text, { mode: "json5" });
+                        }).to.throw("Unexpected token Number found.");
+                    });
+
+                    it("should throw an error when +NaN is used as a property key", () => {
+                        const text = "{ +NaN: 1 }";
+                        
+                        expect(() => {
+                            parse(text, { mode: "json5" });
+                        }).to.throw("Unexpected token Number found.");
+                    });
+
+                    it("should throw an error when -NaN is used as a property key", () => {
+                        const text = "{ -NaN: 1 }";
+
+                        expect(() => {
+                            parse(text, { mode: "json5" });
+                        }).to.throw("Unexpected token Number found.");
+                    });
+
+                    it("should throw an error when +Infinity is used as a property key", () => {
+                        const text = "{ +Infinity: 1 }";
+                        
+                        expect(() => {
+                            parse(text, { mode: "json5" });
+                        }).to.throw("Unexpected token Number found.");
+                    });
+
+                    it("should throw an error when -Infinity is used as a property key", () => {
+                        const text = "{ -Infinity: 1 }";
+
+                        expect(() => {
+                            parse(text, { mode: "json5" });
+                        }).to.throw("Unexpected token Number found.");
+                    });
 
                 });
             });


### PR DESCRIPTION

This pull request includes changes to the `parse` function in `js/src/parse.js` and its corresponding tests in `js/tests/parse.test.js`. The updates focus on improving error handling for invalid property keys in JSON5 mode.


fixes #154

Improvements to error handling:

* [`js/src/parse.js`](diffhunk://#diff-1575fa55691b5b581fa062d582fd4098620a37e1aeedfffefaca32654a1ebfadR404-R408): Added checks to throw an `UnexpectedToken` error when encountering `+NaN`, `-NaN`, `+Infinity`, `-Infinity`, or any number as a property key in JSON5 mode.

Enhancements to tests:

* [`js/tests/parse.test.js`](diffhunk://#diff-5f1d85bda34d24b5f3dd1e2025564486282294f00d31cef0f87913105f5d4c9bR157-R195): Added multiple test cases to ensure the `parse` function throws an `UnexpectedToken` error for invalid property keys such as `123`, `+NaN`, `-NaN`, `+Infinity`, and `-Infinity` in JSON5 mode.