### PR TITLE
fix: Unescape JSON5 identifier values

### DIFF
--- a/js/src/parse.js
+++ b/js/src/parse.js
@@ -50,6 +50,20 @@ const DEFAULT_OPTIONS = {
     allowTrailingCommas: false
 };
 
+const UNICODE_SEQUENCE = /\\u[\da-z]{4}/gu;
+
+/**
+ * Normalizes a JSON5 identifier by converting Unicode escape sequences into
+ * their corresponding characters.
+ * @param {string} identifier The identifier to normalize.
+ * @returns {string} The normalized identifier.
+ */
+function normalizeIdentifier(identifier) {
+    return identifier.replace(UNICODE_SEQUENCE, unicodeEscape => {
+        return String.fromCharCode(parseInt(unicodeEscape.slice(2), 16));
+    });
+}
+
 /**
  * Converts a JSON-encoded string into a JavaScript string, interpreting each
  * escape sequence.
@@ -358,8 +372,7 @@ export function parse(text, options) {
             // check if the token is NaN or Infinity
             return t[identifier.includes("NaN") ? "nan" : "infinity"](/** @type {Sign} */ (sign), parts);
         }
-
-        return t.identifier(identifier, parts);
+        return t.identifier(normalizeIdentifier(identifier), parts);
     }
 
     /**

--- a/js/tests/parse.test.js
+++ b/js/tests/parse.test.js
@@ -245,6 +245,13 @@ describe("parse()", () => {
                     const result = parse(text, { mode: "json5" });
                     expect(result.body.value).to.equal(1);
                 });
+
+                it("should unescape unquoted property names", () => {
+                    const text = "{ f\\u006fo: 1 }";
+                    const expected = json5.parse(text);
+                    const result = parse(text, { mode: "json5" });
+                    expect(result.body.members[0].name.name).to.equal(Object.keys(expected)[0]);
+                });
             });
 
             describe("fixtures", () => {


### PR DESCRIPTION
This pull request includes enhancements to the `parse` function in `js/src/parse.js` and corresponding tests in `js/tests/parse.test.js`. The main changes involve adding a new function to handle Unicode escape sequences in JSON5 identifiers and updating the `parse` function to use this new normalization.

Enhancements to `parse` function:

* [`js/src/parse.js`](diffhunk://#diff-1575fa55691b5b581fa062d582fd4098620a37e1aeedfffefaca32654a1ebfadR53-R66): Added `UNICODE_SEQUENCE` regex and `normalizeIdentifier` function to convert Unicode escape sequences into their corresponding characters.
* [`js/src/parse.js`](diffhunk://#diff-1575fa55691b5b581fa062d582fd4098620a37e1aeedfffefaca32654a1ebfadL361-R375): Updated the `parse` function to use `normalizeIdentifier` for processing identifiers.

Corresponding tests:

* [`js/tests/parse.test.js`](diffhunk://#diff-5f1d85bda34d24b5f3dd1e2025564486282294f00d31cef0f87913105f5d4c9bR248-R254): Added a test case to ensure unquoted property names with Unicode escape sequences are correctly unescaped.

fixes #164