### PR TITLE
fix(types): Parse options should be a partial

### DIFF
--- a/js/src/parse.js
+++ b/js/src/parse.js
@@ -208,7 +208,7 @@ function getLiteralValue(value, token, json5 = false) {
 /**
  * 
  * @param {string} text The text to parse.
- * @param {ParseOptions} [options] The options object.
+ * @param {Partial<ParseOptions>} [options] The options object.
  * @returns {DocumentNode} The AST representing the parsed JSON.
  * @throws {Error} When there is a parsing error. 
  */


### PR DESCRIPTION
Currently if you try to provide only one options key, you'll get a type error, despite the following in the README:

> which is an options object that may contain one or more of the following properties:
