### PR TITLE
fix: throw UnexpectedEOF for empty input instead of crashing

### DIFF
--- a/js/src/parse.js
+++ b/js/src/parse.js
@@ -632,6 +632,14 @@ export function parse(text, options) {
 
         tokenType = tokenType ?? next();
         const token = tokenizer.token;
+
+        if (!tokenType) {
+            throw new UnexpectedEOF({
+                line: 1,
+                column: 1,
+                offset: 0
+            });
+        }
         
         switch (tokenType) {
             case tt.String:

--- a/js/tests/parse.test.js
+++ b/js/tests/parse.test.js
@@ -35,6 +35,18 @@ describe("parse()", () => {
         describe(name, () => {
 
             describe("error", () => {
+                it("should throw an error when input is empty", () => {
+                    expect(() => {
+                        parse("");
+                    }).to.throw("Unexpected end of input found.");
+                });
+
+                it("should throw an error when input is only whitespace", () => {
+                    expect(() => {
+                        parse("   ");
+                    }).to.throw("Unexpected end of input found.");
+                });
+
                 it("should throw an error when an unexpected token is found", () => {
                     const text = "\"hi\"123";
 


### PR DESCRIPTION
Fixes #221

Parsing an empty string (or whitespace-only input) hits the `default` branch in `parseValue` where `tokenizer.token` is undefined, so `new UnexpectedToken(token)` blows up with a TypeError on `token.type`.

Added an early `!tokenType` guard that throws `UnexpectedEOF` before reaching the switch — same error class the rest of the parser already uses for premature end-of-input. Tests for empty and whitespace-only input included.

— saschabuehrle